### PR TITLE
Fix layer id

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -159,7 +159,7 @@ ol.control.LayerSwitcher.prototype.renderLayer_ = function(lyr, idx) {
     var li = document.createElement('li');
 
     var lyrTitle = lyr.get('title');
-    var lyrId = lyr.get('title').replace(' ', '-') + '_' + idx;
+    var lyrId = lyr.get('title').replace(/\s+/g, '-') + '_' + idx;
 
     var label = document.createElement('label');
 


### PR DESCRIPTION
In the DOM, an ID is assigned to each layer. The ID is generated by replacing spaces with hyphens.

Currently, the replace function will only find the first space and replace it with a hyphen. All other spaces remain. This creates an invalid and unselectable ID. In my case, my layer had the ID `#Above-Ground Tunnels _2`.

The proposed change will replace all spaces and results in the correctly hyphenated `#Above-Ground-Tunnels_2`.

![image](https://cloud.githubusercontent.com/assets/1809908/11097329/c38b417a-886c-11e5-99d6-72bacd5d978d.png)