### PR TITLE
prevent default onclick

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -37,6 +37,7 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     button.onclick = function(e) {
         this_.showPanel();
+        e.preventDefault();
     };
 
     element.onmouseout = function(e) {


### PR DESCRIPTION
Hi,

When clicking on the layer switcher button, the default event is triggered. If the openlayer map happens to be in a <form>, this will submit the form, which is of course not expected.
This PR fixes this.

Thanks for the plugin !