### PR TITLE
Use an ol.layer.Group as a base layer

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -169,7 +169,7 @@ ol.control.LayerSwitcher.prototype.renderLayer_ = function(lyr, idx) {
 
     var label = document.createElement('label');
 
-    if (lyr.getLayers) {
+    if (lyr.get('type') !== 'base' && lyr.getLayers) {
 
         li.className = 'group';
         label.innerHTML = lyrTitle;


### PR DESCRIPTION
If an ol.layer.Group has the type property set to 'base', treat it as a regular layer (ol.layer.Layer). Sometimes the user would want to turn a collection of layers on and off, not just single layers.