### PR TITLE
disable checkbox and grey out layername if layer is outside of resolution constraint

### DIFF
--- a/examples/addlayer.html
+++ b/examples/addlayer.html
@@ -4,14 +4,7 @@
     <meta charset="utf-8" />
     <title>OpenLayers 3 - LayerSwitcher Add Layer</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
-    <!-- Limit the dimensions of the map to avoid requesting images too large for the ESRI image service -->
-    <style type="text/css">
-        #map {
-            max-width: 800px;
-            max-height: 800px;
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol.css" />
     <link rel="stylesheet" href="../src/ol3-layerswitcher.css" />
     <link rel="stylesheet" href="layerswitcher.css" />
   </head>
@@ -19,7 +12,7 @@
     <div id="map"></div>
     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol.js"></script>
     <script src="../src/ol3-layerswitcher.js"></script>
     <script src="addlayer.js"></script>
   </body>

--- a/examples/addlayer.html
+++ b/examples/addlayer.html
@@ -4,6 +4,13 @@
     <meta charset="utf-8" />
     <title>OpenLayers 3 - LayerSwitcher Add Layer</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <!-- Limit the dimensions of the map to avoid requesting images too large for the ESRI image service -->
+    <style type="text/css">
+        #map {
+            max-width: 800px;
+            max-height: 800px;
+        }
+    </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.17.1/ol.css" />
     <link rel="stylesheet" href="../src/ol3-layerswitcher.css" />
     <link rel="stylesheet" href="layerswitcher.css" />

--- a/examples/addlayer.js
+++ b/examples/addlayer.js
@@ -4,7 +4,8 @@
     // but add the overlay layers later
     var overlayGroup = new ol.layer.Group({
         title: 'Overlays',
-        layers: []
+        layers: [
+        ]
     });
 
     // Create a map containing two group layers
@@ -24,8 +25,8 @@
             overlayGroup
         ],
         view: new ol.View({
-            center: [-10997148, 4569099],
-            zoom: 4
+            center: ol.proj.transform([-0.92, 52.96], 'EPSG:4326', 'EPSG:3857'),
+            zoom: 6
         })
     });
 
@@ -36,45 +37,17 @@
     // Add a layer to a pre-exiting ol.layer.Group after the LayerSwitcher has
     // been added to the map. The layer will appear in the list the next time
     // the LayerSwitcher is shown or LayerSwitcher#renderPanel is called.
-
-    url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StatesCitiesRivers_USA/MapServer";
     overlayGroup.getLayers().push(
-            new ol.layer.Image({
-                title: 'States',
-                minResolution: 500,
-                maxResolution: 50000,
-                source: new ol.source.ImageArcGISRest({
-                    ratio: 1,
-                    params: {'LAYERS': 'show:2'},
-                    url: url
-                })
+        new ol.layer.Image({
+            title: 'Countries',
+            minResolution: 500,
+            maxResolution: 5000,
+            source: new ol.source.ImageArcGISRest({
+                ratio: 1,
+                params: {'LAYERS': 'show:0'},
+                url: "https://ons-inspire.esriuk.com/arcgis/rest/services/Administrative_Boundaries/Countries_December_2016_Boundaries/MapServer"
             })
-    );
-
-    overlayGroup.getLayers().push(
-            new ol.layer.Image({
-                title: 'Rivers',
-                minResolution: 0,
-                maxResolution: 5000,
-                source: new ol.source.ImageArcGISRest({
-                    ratio: 1,
-                    params: {'LAYERS': 'show:1'},
-                    url: url
-                })
-            })
-    );
-
-    overlayGroup.getLayers().push(
-            new ol.layer.Image({
-                title: 'Cities',
-                minResolution: 0,
-                maxResolution: 3000,
-                source: new ol.source.ImageArcGISRest({
-                    ratio: 1,
-                    params: {'LAYERS': 'show:0'},
-                    url: url
-                })
-            })
+        })
     );
 
 })();

--- a/examples/addlayer.js
+++ b/examples/addlayer.js
@@ -4,8 +4,7 @@
     // but add the overlay layers later
     var overlayGroup = new ol.layer.Group({
         title: 'Overlays',
-        layers: [
-        ]
+        layers: []
     });
 
     // Create a map containing two group layers
@@ -25,8 +24,8 @@
             overlayGroup
         ],
         view: new ol.View({
-            center: ol.proj.transform([-0.92, 52.96], 'EPSG:4326', 'EPSG:3857'),
-            zoom: 6
+            center: [-10997148, 4569099],
+            zoom: 4
         })
     });
 
@@ -37,13 +36,45 @@
     // Add a layer to a pre-exiting ol.layer.Group after the LayerSwitcher has
     // been added to the map. The layer will appear in the list the next time
     // the LayerSwitcher is shown or LayerSwitcher#renderPanel is called.
-    overlayGroup.getLayers().push(new ol.layer.Tile({
-        title: 'Countries',
-        source: new ol.source.TileWMS({
-            url: 'http://demo.opengeo.org/geoserver/wms',
-            params: {'LAYERS': 'ne:ne_10m_admin_1_states_provinces_lines_shp'},
-            serverType: 'geoserver'
-        })
-    }));
+
+    url = "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StatesCitiesRivers_USA/MapServer";
+    overlayGroup.getLayers().push(
+            new ol.layer.Image({
+                title: 'States',
+                minResolution: 500,
+                maxResolution: 50000,
+                source: new ol.source.ImageArcGISRest({
+                    ratio: 1,
+                    params: {'LAYERS': 'show:2'},
+                    url: url
+                })
+            })
+    );
+
+    overlayGroup.getLayers().push(
+            new ol.layer.Image({
+                title: 'Rivers',
+                minResolution: 0,
+                maxResolution: 5000,
+                source: new ol.source.ImageArcGISRest({
+                    ratio: 1,
+                    params: {'LAYERS': 'show:1'},
+                    url: url
+                })
+            })
+    );
+
+    overlayGroup.getLayers().push(
+            new ol.layer.Image({
+                title: 'Cities',
+                minResolution: 0,
+                maxResolution: 3000,
+                source: new ol.source.ImageArcGISRest({
+                    ratio: 1,
+                    params: {'LAYERS': 'show:0'},
+                    url: url
+                })
+            })
+    );
 
 })();

--- a/src/ol3-layerswitcher.css
+++ b/src/ol3-layerswitcher.css
@@ -73,6 +73,11 @@
     vertical-align: sub;
 }
 
+.layer-switcher li.disabled {
+    pointer-events:none;
+    opacity:0.4;
+}
+
 .layer-switcher input {
     margin: 4px;
 }

--- a/src/ol3-layerswitcher.css
+++ b/src/ol3-layerswitcher.css
@@ -73,8 +73,7 @@
     vertical-align: sub;
 }
 
-.layer-switcher li.disabled {
-    pointer-events:none;
+.layer-switcher label.disabled {
     opacity:0.4;
 }
 

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -197,6 +197,11 @@
                 input.name = 'base';
             } else {
                 input.type = 'checkbox';
+                var rsl = this.getMap().getView().getResolution();
+                if (rsl > lyr.getMaxResolution() || rsl < lyr.getMinResolution()){
+                    li.className += ' disabled';
+                    input.disabled = true; // css only solution not working in IE
+                }
             }
             input.id = lyrId;
             input.checked = lyr.get('visible');

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -197,11 +197,6 @@
                 input.name = 'base';
             } else {
                 input.type = 'checkbox';
-                var rsl = this.getMap().getView().getResolution();
-                if (rsl > lyr.getMaxResolution() || rsl < lyr.getMinResolution()){
-                    li.className += ' disabled';
-                    input.disabled = true; // css only solution not working in IE
-                }
             }
             input.id = lyrId;
             input.checked = lyr.get('visible');
@@ -212,6 +207,12 @@
 
             label.htmlFor = lyrId;
             label.innerHTML = lyrTitle;
+
+            var rsl = this.getMap().getView().getResolution();
+            if (rsl > lyr.getMaxResolution() || rsl < lyr.getMinResolution()){
+                label.className += ' disabled';
+            }
+
             li.appendChild(label);
 
         }

--- a/test/spec/ol3-layerswitcher.js
+++ b/test/spec/ol3-layerswitcher.js
@@ -105,6 +105,8 @@ describe('ol.control.LayerSwitcher', function() {
                 }),
                 new ol.layer.Tile({
                     title: 'Bar',
+                    minResolution: 1000,
+                    maxResolution: 5000,
                     source: new ol.source.TileDebug({
                         projection: 'EPSG:3857',
                         tileGrid: ol.tilegrid.createXYZ({
@@ -184,6 +186,18 @@ describe('ol.control.LayerSwitcher', function() {
                 return jQuery(this).text();
             }).get();
             expect(titles).to.eql(['Bar', 'Combined-Overlay-Group']);
+        });
+        it('greys out normal layer title lables when outside of layer resolution', function() {
+            map.getView().setResolution(6000);
+            switcher.showPanel();
+            var layerResTooHigh = jQuery('.layer-switcher label.disabled').map(function() {
+                return jQuery(this).text();
+            }).get();
+            map.getView().setResolution(500);
+            var layerResTooLow = jQuery('.layer-switcher label.disabled').map(function() {
+                return jQuery(this).text();
+            }).get();
+            expect([layerResTooHigh, layerResTooLow]).to.eql([['Bar'], ['Bar']]);
         });
         it('displays base layers as radio buttons', function() {
             switcher.showPanel();


### PR DESCRIPTION
Hi!

Referencing [issue #25 ](https://github.com/walkermatt/ol3-layerswitcher/issues/25) I have implemented the  discussed option B.

- checkboxes of overlays are disabled and the list item (layername) is greyed out if the map resolution is outside of min/max resolution of the layer
- changed the example "addlayer" to see the changes in action

By the way, the "Countries" layer you are using in all your example doesn't seem to be working anymore. 