### PR TITLE
Add or remove .shown in className instead of use a predefine className

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -28,7 +28,7 @@
         if (ol.control.LayerSwitcher.isTouchDevice_()) {
             this.hiddenClassName += ' touch';
         }
-        this.shownClassName = this.hiddenClassName + ' shown';
+        this.shownClassName = 'shown';
 
         var element = document.createElement('div');
         element.className = this.hiddenClassName;
@@ -74,8 +74,9 @@
      * Show the layer panel.
      */
     ol.control.LayerSwitcher.prototype.showPanel = function() {
-        if (this.element.className != this.shownClassName) {
-            this.element.className = this.shownClassName;
+        var classes = this.element.className.split(' ');
+        if (classes.indexOf(this.shownClassName)<0) {
+            this.element.className += ' '+this.shownClassName;
             this.renderPanel();
         }
     };
@@ -84,8 +85,11 @@
      * Hide the layer panel.
      */
     ol.control.LayerSwitcher.prototype.hidePanel = function() {
-        if (this.element.className != this.hiddenClassName) {
-            this.element.className = this.hiddenClassName;
+        var classes = this.element.className.split(' ');
+        var index = classes.indexOf(this.shownClassName);
+        if (index>=0) {
+            classes.splice(index, 1);
+            this.element.className = classes.join(' ');
         }
     };
 

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -74,9 +74,8 @@
      * Show the layer panel.
      */
     ol.control.LayerSwitcher.prototype.showPanel = function() {
-        var classes = this.element.className.split(' ');
-        if (classes.indexOf(this.shownClassName)<0) {
-            this.element.className += ' '+this.shownClassName;
+        if (!this.element.classList.contains(this.shownClassName)) {
+            this.element.classList.add(this.shownClassName);
             this.renderPanel();
         }
     };
@@ -85,11 +84,8 @@
      * Hide the layer panel.
      */
     ol.control.LayerSwitcher.prototype.hidePanel = function() {
-        var classes = this.element.className.split(' ');
-        var index = classes.indexOf(this.shownClassName);
-        if (index>=0) {
-            classes.splice(index, 1);
-            this.element.className = classes.join(' ');
+        if (this.element.classList.contains(this.shownClassName)) {
+            this.element.classList.remove(this.shownClassName);
         }
     };
 


### PR DESCRIPTION
In frameworks like polymer to simulate the shadow DOM in browsers which not support it, a class wrapper is added to isolate the styles in each of them.

In this case, the plugin replaces the className completely when it show/hide the layer list and removing other class previously added by other frameworks.

From my point, the simpler way to avoid this is adding or removing the .shown class without replacing entirely the className.

I run the tests and all are ok.